### PR TITLE
Update filetypes.js

### DIFF
--- a/src/filetypes.js
+++ b/src/filetypes.js
@@ -2,6 +2,7 @@
 
 const classRegex = /class=["|']([\w- ]*$)/
 const classNameRegex = /className=["|']([\w- ]*$)/
+const classNameJsRegex = /className:["|']([\w- ]*$)/
 const applyRegex = /@apply ([\.\w- ]*$)/
 const emmetRegex = /(?=\.)([\w-\. ]*$)/
 
@@ -12,6 +13,10 @@ const jsPatterns = [
   },
   {
     regex: classNameRegex,
+    splitCharacter: ' '
+  },
+  {
+    regex: classNameJsRegex,
     splitCharacter: ' '
   },
   {


### PR DESCRIPTION
If you do work with Hyperscript, there is a a slightly different syntax to declare a `css class`. So instead of using `=`, they use `:`, would be great if you can merge it. Would like to use your plugin for my day to day work. 

```js
const fullCardViewLearnMode = dispatch => model => {
    return div({ className: 'container mx-auto border p-10' }, [
        h1({ className: 'my-8' }, 'Learn Cards'),
    ])
}
```